### PR TITLE
feat: Add rudimentary export functionality to retrieve files from vaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.vault
 .vscode/
+src/.vault/vault.manifest

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -39,6 +39,13 @@ enum Commands {
         #[arg(short = 'p', long)]
         vault_path: Option<String>,
     },
+    Export{
+        vault_path: String,
+        #[arg(short = 'v', long)]
+        vault_name: String,
+        #[arg(short = 'p', long)]
+        host_path: String,
+    }
 }
 
 // Represents a vault in the Vault directory
@@ -133,6 +140,23 @@ fn main() {
                 if let Ok(()) = manager.import_file(&vault_name, &vault_destination, &content) {
                 } else {
                     eprintln!("Failed to import file into vault '{}'.", vault_name);
+                }
+            } else {
+                eprintln!(
+                    "Failed to unlock vault '{}'. Please check the name and password.",
+                    vault_name
+                );
+            }
+        },
+        Commands::Export { vault_path, vault_name, host_path } => {
+            let password: String = rpassword::prompt_password("Enter vault password: ")
+                .expect("Failed to read password");
+            let vault_path: PathBuf = PathBuf::from(vault_path);
+            if manager.unlock_vault(&vault_name, &password).is_ok() {
+                if let Ok(content) = manager.export_file(&vault_name, &vault_path) {
+                    fs::write(&host_path, content).expect("Failed to write file to host path");
+                } else {
+                    eprintln!("Failed to export file from vault '{}'.", vault_name);
                 }
             } else {
                 eprintln!(

--- a/src/core/cache.rs
+++ b/src/core/cache.rs
@@ -105,7 +105,8 @@ impl DirectoryCache {
     /// * `root_listing` - The `DirectoryListing` for the vault's root path (`/`).
     pub fn init(&self, root_listing: DirectoryListing) {
         let mut internal = self.internal.lock().unwrap();
-        internal.cache.put(PathBuf::from("/"), root_listing);
+        internal.cache.put(PathBuf::from("/"), root_listing.clone());
+        internal.cache.put(PathBuf::from(""), root_listing.clone());
     }
 
     /// Retrieves a directory listing, using the cache if possible or fetching from the vault.

--- a/src/core/manager.rs
+++ b/src/core/manager.rs
@@ -200,6 +200,29 @@ ____   ____            .__   __
         );
         Ok(())
     }
+
+    pub fn export_file(
+        &self,
+        vault_name: &str,
+        vault_path: &Path,
+    ) -> Result<Vec<u8>, VaultError> {
+        let vault = self
+            .unlocked_vaults
+            .get(vault_name)
+            .ok_or(VaultError::VaultNotFound)?;
+        eprintln!(
+            "(manager)Exporting file from vault '{}': {}",
+            vault_name,
+            vault_path.display()
+        );
+        let content = vault.export_file(vault_path)?;
+        println!(
+            "Successfully exported from {}:{}",
+            vault_name,
+            vault_path.display()
+        );
+        Ok(content)
+    }
 }
 
 /// Helper functions for VaultManager go here

--- a/src/core/vault.rs
+++ b/src/core/vault.rs
@@ -3,7 +3,6 @@ use crate::core::crypto::{self, SecureKey, decrypt, encrypt, generate_dek};
 use crate::core::error::VaultError;
 use crate::core::storage::{StorageBackend, connect};
 use base64::Engine;
-use indexmap::map::raw_entry_v1;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;

--- a/src/core/vault.rs
+++ b/src/core/vault.rs
@@ -1,8 +1,9 @@
 use crate::core::cache::DirectoryCache;
-use crate::core::crypto::{self, SecureKey, encrypt, generate_dek};
+use crate::core::crypto::{self, SecureKey, decrypt, encrypt, generate_dek};
 use crate::core::error::VaultError;
 use crate::core::storage::{StorageBackend, connect};
 use base64::Engine;
+use indexmap::map::raw_entry_v1;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
@@ -234,5 +235,35 @@ impl UnlockedVault {
         );
         println!("Current Listing: {:#?}", current_listing);
         Ok(())
+    }
+
+    pub fn export_file(&self, path: &Path) -> Result<Vec<u8>, VaultError> {
+        let parent = path.parent().unwrap_or(Path::new("/"));
+
+        eprintln!("(vault) Exporting file from path: {}", parent.display());
+
+        let current_listing = self.directory_cache.get_directory_listing(parent, &self)?;
+
+        eprintln!("(vault) Current listing: {:?}", current_listing);
+
+        let file_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or(VaultError::ResourceNotFound)?;
+
+        let file_metadata = current_listing
+            .files
+            .get(file_name)
+            .ok_or(VaultError::ResourceNotFound)?;
+
+        let blob_id = &file_metadata.blob_id;
+
+        let raw_blob_data = self
+            .storage
+            .get_blob(blob_id)
+            .map_err(|_| VaultError::ResourceNotFound)?;
+
+        let decrypted_blob = decrypt(&raw_blob_data, &self.content_key)?;
+        Ok(decrypted_blob)
     }
 }


### PR DESCRIPTION
This pull request adds an "export file" feature to the vault application, allowing users to securely export a file from a vault to a specified host path. It introduces a new CLI command, implements the necessary backend logic to retrieve and decrypt the file, and ensures proper error handling and user prompts.

**New Export Feature:**

* Added a new `Export` command to the CLI, allowing users to specify a vault, the file path within the vault, and a destination path on the host for export.
* Implemented the CLI logic to prompt for the vault password, unlock the vault, call the export function, and write the exported file to the host.

**Backend and Core Logic:**

* Added `VaultManager::export_file`, which retrieves and decrypts the specified file from an unlocked vault.
* Added `UnlockedVault::export_file`, which locates the file in the vault, fetches the encrypted blob, decrypts it, and returns the content.
* Updated imports in `vault.rs` to include the `decrypt` function required for file export.

**Cache Improvement:**

* Improved `DirectoryCache::init` to cache both the root path `/` and an empty path `""`, improving consistency when a file stored at the root of the directory is requested.